### PR TITLE
Require 'open3' explicitly in command.rb.

### DIFF
--- a/lib/dockerhelper/command.rb
+++ b/lib/dockerhelper/command.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module Dockerhelper
   class Command
     attr_reader :cmd, :label, :chdir


### PR DESCRIPTION
It didn't work for me without this, with ruby 2.1.5 or 2.2.2.