### PR TITLE
Add config option for required environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ config = Dockerhelper.configure do |c|
   c.docker_repo_tag_prefix  = 'prd-'
   c.kube_rc_template        = File.expand_path('../project-rc.yml.erb', __FILE__)
   c.kube_rc_dest_dir        = File.dirname(__FILE__)
+  c.env_vars                = %w(REQUIRED_ENV_VAR)
 end
 
 Dockerhelper::Tasks.init(config)

--- a/lib/dockerhelper.rb
+++ b/lib/dockerhelper.rb
@@ -12,8 +12,6 @@ module Dockerhelper
   module_function :cmd
 
   def self.configure(&block)
-    config = Config.new
-    block.call(config)
-    config
+    Config.new.tap(&block).tap(&:check_env_vars!)
   end
 end

--- a/lib/dockerhelper/config.rb
+++ b/lib/dockerhelper/config.rb
@@ -13,6 +13,7 @@ module Dockerhelper
     attr_accessor :environment
     attr_accessor :kube_rc_template
     attr_accessor :kube_rc_dest_dir
+    attr_accessor :env_vars
 
     def initialize
       # defaults
@@ -34,6 +35,17 @@ module Dockerhelper
 
     def docker_repo_tag
       @docker_tag || "#{docker_repo_tag_prefix}#{git.latest_rev}"
+    end
+
+    def check_env_vars!
+      return unless @env_vars
+      unless @env_vars.respond_to?(:reject)
+        raise ArgumentError.new('Expected an array of env_vars')
+      end
+      undefined = @env_vars.reject(&ENV.method(:has_key?))
+      unless undefined.empty?
+        raise StandardError.new("The environment must define #{undefined.join ', '}")
+      end
     end
   end
 end


### PR DESCRIPTION
If any of the required env vars are not defined, an exception will be raised.

@joshm1 - I'm not really in love with this.  It's kind of heavy-handed, for example, you can't even run `rake -T` without the required env vars being defined.  Any ideas to make this better?