### PR TITLE
Add an option for a custom build command to run before docker build.

### DIFF
--- a/lib/dockerhelper/config.rb
+++ b/lib/dockerhelper/config.rb
@@ -13,6 +13,7 @@ module Dockerhelper
     attr_accessor :environment
     attr_accessor :kube_rc_template
     attr_accessor :kube_rc_dest_dir
+    attr_accessor :prebuild_command
 
     def initialize
       # defaults
@@ -34,6 +35,10 @@ module Dockerhelper
 
     def docker_repo_tag
       @docker_tag || "#{docker_repo_tag_prefix}#{git.latest_rev}"
+    end
+
+    def prebuild?
+      @prebuild_command && !@prebuild_command.empty?
     end
   end
 end

--- a/lib/dockerhelper/rake.rb
+++ b/lib/dockerhelper/rake.rb
@@ -13,6 +13,11 @@ module Dockerhelper
             puts config.inspect
           end
 
+          desc 'Prepare to build docker image'
+          task :prebuild do
+            Command.new(config.prebuild_command, label: 'prebuild').run if config.prebuild?
+          end
+
           desc 'Build docker image'
           task :docker_build do
             config.docker.build(config.dockerfile, tag: config.docker_image)
@@ -35,7 +40,7 @@ module Dockerhelper
           end
 
           desc 'Git clone, build image, and push image to Docker Hub'
-          task :build => [:pull, :docker_build, :repo_tag, :push, 'kube:gen_rc']
+          task :build => [:pull, :prebuild, :docker_build, :repo_tag, :push, 'kube:gen_rc']
 
           namespace :kube do
             desc 'Generate replication controller for the current build'
@@ -70,4 +75,3 @@ module Dockerhelper
     end
   end
 end
-


### PR DESCRIPTION
Some projects might need this to build from the clean checkout to avoid including unnecessary dependencies in the docker image.